### PR TITLE
Support "query" in api-mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,23 +24,22 @@
     "release": "yoshi release"
   },
   "dependencies": {
-    "@types/enzyme": "^3.1.15",
-    "@types/enzyme-adapter-react-16": "^1.0.3",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.7.1",
-    "react": "^16.6.3",
-    "react-dom": "^16.6.3"
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.15",
     "@types/node": "^8.0.0",
-    "@types/react-dom": "^16.6.3",
+    "@types/react": "^16.9.31",
+    "@types/react-dom": "^16.9.6",
     "husky": "~0.14.0",
     "jest-yoshi-preset": "^4.9.5",
     "lint-staged": "^7.2.2",
     "puppeteer": "^1.11.0",
-    "react-test-renderer": "~16.6.3",
-    "typescript": "^3.5.2",
+    "react-test-renderer": "^16.8.3",
+    "typescript": "^3.9.0",
     "yoshi": "^4.9.6"
   },
   "lint-staged": {

--- a/src/api-mocks.ts
+++ b/src/api-mocks.ts
@@ -1,6 +1,7 @@
 export interface ApiMock {
   method: Method;
   url: string;
+  query?: any;
   status?: number;
   response: any;
   body?: any;
@@ -14,6 +15,7 @@ export enum Method {
 export interface ApiMockRequestBuilder {
   method?: Method;
   url: string;
+  query?: any;
   body?: any;
 }
 
@@ -25,12 +27,14 @@ export interface ApiMockResponseBuilder {
 export const createApiMock = ({
   method = Method.GET,
   url,
-  body = null,
+  query,
+  body,
 }: ApiMockRequestBuilder) => ({
   replyWith({ status = 200, response }: ApiMockResponseBuilder): ApiMock {
     return {
       method,
       url,
+      query,
       response,
       body,
       status,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,10 @@ export {
   TestDriver,
   driverFactory,
 } from './test-driver/test-driver';
+export {
+  Method,
+  ApiMock,
+  ApiMockRequestBuilder,
+  ApiMockResponseBuilder,
+  createApiMock,
+} from './api-mocks'

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,4 @@ export {
   ApiMockRequestBuilder,
   ApiMockResponseBuilder,
   createApiMock,
-} from './api-mocks'
+} from './api-mocks';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,2 +1,2 @@
-export const applyChanges = () => new Promise(resolve => setTimeout(resolve));
+export const applyChanges = () => new Promise((resolve) => setTimeout(resolve));
 export const byDataHook = (hook: string) => `[data-hook="${hook}"]`;


### PR DESCRIPTION
Changelog:
- Update dependencies
- Add `query` field to `ApiMock`
- Export `api-mocks` on top-level